### PR TITLE
Potential fix for code scanning alert no. 10: Prototype-polluting assignment

### DIFF
--- a/intranet-frontend/src/services/orbitSchedules.js
+++ b/intranet-frontend/src/services/orbitSchedules.js
@@ -752,6 +752,18 @@ async function applyRemoteTransform(transform) {
   const norm = normalizeTransform(transform)
   if (!norm) return
   const { op, scheduleId, entry, rows } = norm
+
+  // validate scheduleId to prevent prototype pollution via special keys
+  if (scheduleId == null || (typeof scheduleId !== 'string' && typeof scheduleId !== 'number')) {
+    try { console.warn('applyRemoteTransform: ignoring transform with invalid scheduleId', scheduleId) } catch (e) {}
+    return
+  }
+  const scheduleKey = String(scheduleId)
+  if (scheduleKey === '__proto__' || scheduleKey === 'constructor' || scheduleKey === 'prototype') {
+    try { console.warn('applyRemoteTransform: rejecting transform with unsafe scheduleId', scheduleKey) } catch (e) {}
+    return
+  }
+
   // normalize entry assignment arrays to canonical keys so UI mapping works
   if (entry && typeof entry === 'object') {
     try {
@@ -818,11 +830,11 @@ async function applyRemoteTransform(transform) {
   if (!scheduleId) return
   try {
     // load current rows into memory (or from IDB)
-    if (!memoryStore[scheduleId]) {
-      const fromIdb = await idbGet(scheduleId)
-      memoryStore[scheduleId] = Array.isArray(fromIdb) ? fromIdb : []
+    if (!memoryStore[scheduleKey]) {
+      const fromIdb = await idbGet(scheduleKey)
+      memoryStore[scheduleKey] = Array.isArray(fromIdb) ? fromIdb : []
     }
-    const rows = memoryStore[scheduleId]
+    const rows = memoryStore[scheduleKey]
       if (op === 'create') {
         // avoid duplicates by id (string-safe comparison)
         if (!rows.find(r => String(r.id) === String(entry.id))) rows.push(entry)


### PR DESCRIPTION
Potential fix for [https://github.com/jorblad/intranet/security/code-scanning/10](https://github.com/jorblad/intranet/security/code-scanning/10)

In general, to fix prototype-pollution risks from untrusted keys, either (1) store data in structures that don’t inherit from `Object.prototype` (e.g., `Map` or `Object.create(null)`), or (2) validate and reject dangerous keys before using them as property names. Here, the minimal, non-breaking change is to keep `memoryStore` as a plain object but guard against dangerous `scheduleId` values before indexing into it.

The specific best fix in this file is to validate `scheduleId` in `applyRemoteTransform` before the first use of `memoryStore[scheduleId]`. If `scheduleId` is missing, not a string/number, or equals `__proto__`, `prototype`, or `constructor`, we should abort processing that transform to avoid ever assigning to those special properties. We can implement this with a small helper function placed near `applyRemoteTransform` or inlined directly before we touch `memoryStore[scheduleId]`. No external libraries are needed.

Concretely: inside `applyRemoteTransform`, right after `const { op, scheduleId, entry, rows } = norm` (line 754) and before any use of `scheduleId`, add a guard such as:

```js
if (
  scheduleId == null ||
  (typeof scheduleId !== 'string' && typeof scheduleId !== 'number')
) {
  return
}
const scheduleKey = String(scheduleId)
if (scheduleKey === '__proto__' || scheduleKey === 'constructor' || scheduleKey === 'prototype') {
  return
}
```

Then replace later uses of `scheduleId` as an object key with `scheduleKey`, e.g.,

```js
if (!memoryStore[scheduleKey]) {
  const fromIdb = await idbGet(scheduleKey)
  memoryStore[scheduleKey] = Array.isArray(fromIdb) ? fromIdb : []
}
const rows = memoryStore[scheduleKey]
```

This keeps existing functionality for all legitimate IDs while ensuring that the potentially dangerous prototype keys are never used, eliminating the path that could pollute `Object.prototype`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
