### PR TITLE
Fix user selectors

### DIFF
--- a/intranet-frontend/src/pages/TermSchedules.vue
+++ b/intranet-frontend/src/pages/TermSchedules.vue
@@ -307,6 +307,7 @@
                   counter
                   menu-anchor="top left"
                   menu-self="bottom left"
+                  popup-content-class="term-schedules-select-popup"
                 />
               </q-popup-edit>
             </q-td>
@@ -338,6 +339,7 @@
                   counter
                   menu-anchor="top left"
                   menu-self="bottom left"
+                  popup-content-class="term-schedules-select-popup"
                 />
               </q-popup-edit>
             </q-td>
@@ -369,6 +371,7 @@
                   counter
                   menu-anchor="top left"
                   menu-self="bottom left"
+                  popup-content-class="term-schedules-select-popup"
                 />
               </q-popup-edit>
             </q-td>
@@ -499,6 +502,7 @@
             :label="$t('termschedules.responsible_label')"
             menu-anchor="top left"
             menu-self="bottom left"
+            popup-content-class="term-schedules-select-popup"
           />
           <q-select
             filled
@@ -511,6 +515,7 @@
             :label="$t('termschedules.devotional_label')"
             menu-anchor="top left"
             menu-self="bottom left"
+            popup-content-class="term-schedules-select-popup"
           />
           <q-select
             filled
@@ -523,6 +528,7 @@
             :label="$t('termschedules.cant_come_label')"
             menu-anchor="top left"
             menu-self="bottom left"
+            popup-content-class="term-schedules-select-popup"
           />
           <markdown-editor v-model="editedRow.notes" />
           <q-toggle
@@ -616,7 +622,7 @@
                   <q-checkbox v-model="bulkApply.responsible" :label="$t('termschedules.responsible_label')" />
                 </div>
                 <div class="col-12 col-sm-8">
-                  <q-select v-model="bulkForm.responsible" :options="formattedUsers" multiple use-chips :disabled="!bulkApply.responsible" :label="$t('termschedules.responsible_label')" menu-anchor="top left" menu-self="bottom left" />
+                  <q-select v-model="bulkForm.responsible" :options="formattedUsers" multiple use-chips :disabled="!bulkApply.responsible" :label="$t('termschedules.responsible_label')" menu-anchor="top left" menu-self="bottom left" popup-content-class="term-schedules-select-popup" />
                 </div>
               </div>
             </div>
@@ -627,7 +633,7 @@
                   <q-checkbox v-model="bulkApply.devotional" :label="$t('termschedules.devotional_label')" />
                 </div>
                 <div class="col-12 col-sm-8">
-                  <q-select v-model="bulkForm.devotional" :options="formattedUsers" multiple use-chips :disabled="!bulkApply.devotional" :label="$t('termschedules.devotional_label')" menu-anchor="top left" menu-self="bottom left" />
+                  <q-select v-model="bulkForm.devotional" :options="formattedUsers" multiple use-chips :disabled="!bulkApply.devotional" :label="$t('termschedules.devotional_label')" menu-anchor="top left" menu-self="bottom left" popup-content-class="term-schedules-select-popup" />
                 </div>
               </div>
             </div>
@@ -638,7 +644,7 @@
                   <q-checkbox v-model="bulkApply.cant_come" :label="$t('termschedules.cant_come_label')" />
                 </div>
                 <div class="col-12 col-sm-8">
-                  <q-select v-model="bulkForm.cant_come" :options="formattedUsers" multiple use-chips :disabled="!bulkApply.cant_come" :label="$t('termschedules.cant_come_label')" menu-anchor="top left" menu-self="bottom left" />
+                  <q-select v-model="bulkForm.cant_come" :options="formattedUsers" multiple use-chips :disabled="!bulkApply.cant_come" :label="$t('termschedules.cant_come_label')" menu-anchor="top left" menu-self="bottom left" popup-content-class="term-schedules-select-popup" />
                 </div>
               </div>
             </div>
@@ -819,13 +825,8 @@
 /* Ensure select dropdowns opened inside inline editors/dialogs appear above
   the editor action buttons on desktop. This prevents the options list from
   overlapping or being covered by the Save/Cancel buttons. */
-.q-popup-edit .q-menu,
-.q-popup-edit .q-menu__content,
-.q-popup-edit .q-select__popup,
-.q-popup-edit .q-select__dropdown,
-.q-dialog .q-popup-edit .q-menu,
-.q-dialog .q-popup-edit .q-menu__content
-  z-index: 2050 !important
+.term-schedules-select-popup
+  z-index: 2050
 
 .mobile-card q-td
   display: block


### PR DESCRIPTION
Dropdowns for user selectors now go upwarde instead of down to allow the buttons to be shown at the same time as the list